### PR TITLE
Support For All Regions

### DIFF
--- a/ec2scheduler/aws.conf.dist
+++ b/ec2scheduler/aws.conf.dist
@@ -1,12 +1,10 @@
-[aws_eu]
+[eu-west-1]
 access_key = <your_aws_access_key>
 secret_key = <your_aws_secret_key>
-region = <your_aws_region>
 
-[aws_us]
+[us-east-1]
 access_key = <your_aws_access_key>
 secret_key = <your_aws_secret_key>
-region = <your_aws_region>
 
 [schedule]
 paths = ./schedule.json

--- a/ec2scheduler/scheduler.py
+++ b/ec2scheduler/scheduler.py
@@ -42,13 +42,15 @@ def init(args):
   Args:
     args: CLI arguments.
   """
-  # Setup AWS connection
-  aws_eu = connect_from_conf('aws_eu')
-  aws_us = connect_from_conf('aws_us')
-  ec2_conn['eu-west-1'] = aws_eu['ec2']
-  elb_conn['eu-west-1'] = aws_eu['elb']
-  ec2_conn['us-west-1'] = aws_us['ec2']
-  elb_conn['us-west-1'] = aws_us['elb']
+
+  for region in config.sections():
+    if region == 'schedule':
+      continue
+
+    connection = connect_from_conf(region)
+    ec2_conn[region] = connection['ec2']
+    elb_conn[region] = connection['elb']
+ 
   global schedules
   schedules = get_schedules()
 

--- a/ec2scheduler/scheduler.py
+++ b/ec2scheduler/scheduler.py
@@ -54,7 +54,7 @@ def init(args):
   global schedules
   schedules = get_schedules()
 
-def connect_from_conf(aws_conf):
+def connect_from_conf(aws_region):
   """ Connect to ec2 and elb region
 
     Args:
@@ -63,9 +63,8 @@ def connect_from_conf(aws_conf):
     Returns:
       Dict with ec2 and elb connection object for region
   """
-  aws_access_key = config.get(aws_conf,'access_key','')
-  aws_secret_key = config.get(aws_conf,'secret_key','')
-  aws_region = config.get(aws_conf, 'region','')
+  aws_access_key = config.get(aws_region,'access_key','')
+  aws_secret_key = config.get(aws_region,'secret_key','')
 
   return {
     'ec2':

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto==2.38.0
 configparser==3.3.0r2
 docopt==0.6.2
 wsgiref==0.1.2
+pytz


### PR DESCRIPTION
The idea here is to support for All regions

It changes the following behavior:
- Use config's section as region
  To add a new region just simply add a new section with it. e.g:

```
[eu-west-1]
access_key = <Your_Access_Key_Here>
secret_key = <Your_Secret_Key_Here>
```

It will not consider 'schedule' section as region.

Best Regards
